### PR TITLE
Minor improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,14 @@
 .DS_Store
 alfresco/license/TextLicense.l4j
+/resources/
+/alfresco/license/alfresco.lic
+/alfresco-enterprise-viewer-package-*.zip
+
+/alfresco/resources/oa-alfresco.amp
+/alfresco/resources/oat.war
+/alfresco/resources/OpenAnnotate.war
+/alfresco/resources/pdfium.tar.gz
+/alfresco/resources/tsgrp-opencontent-*-for-acs*.amp
+
+/share/resources/oa-share-external-launcher.amp
+/share/resources/oa-share-webpreview.amp

--- a/README.md
+++ b/README.md
@@ -46,13 +46,13 @@ If you want to use also an ACS license, copy `alfresco.lic` file to `alfresco/li
 
 Copy required resources to `share/resources` folder for Alfresco Share configuration:
 
-```
+```bash
 $ cp resources/Share\ Artifacts/*.amp share/resources
 ```
 
 ## Using
 
-```
+```bash
 docker-compose up --build --force-recreate
 ```
 

--- a/alfresco/Dockerfile
+++ b/alfresco/Dockerfile
@@ -18,7 +18,7 @@ COPY ${RESOURCE_PATH}/opencontent-override-config.xml \
 COPY ${RESOURCE_PATH}/opencontent-override-module-context.xml \
         ${TOMCAT_DIR}/shared/classes/alfresco/module/com.tsgrp.opencontent/
 
-COPY ${RESOURCE_PATH}/*.amp ${TOMCAT_DIR}/amps
+COPY ${RESOURCE_PATH}/*.amp ${TOMCAT_DIR}/amps/
 RUN java -jar ${TOMCAT_DIR}/alfresco-mmt/alfresco-mmt*.jar install \
               ${TOMCAT_DIR}/amps ${TOMCAT_DIR}/webapps/alfresco -directory -nobackup -force
 

--- a/share/Dockerfile
+++ b/share/Dockerfile
@@ -7,7 +7,7 @@ ARG RESOURCE_PATH=resources
 
 RUN sed -i 's|shared.loader=\${catalina.base}\/shared\/classes|shared.loader="\${catalina.base}\/shared\/classes","\${catalina.base}\/shared\/lib"|g' ${TOMCAT_DIR}/conf/catalina.properties
 
-COPY $RESOURCE_PATH/*.amp ${TOMCAT_DIR}/amps_share
+COPY $RESOURCE_PATH/*.amp ${TOMCAT_DIR}/amps_share/
 
 RUN java -jar ${TOMCAT_DIR}/alfresco-mmt/alfresco-mmt*.jar install \
               ${TOMCAT_DIR}/amps_share ${TOMCAT_DIR}/webapps/share -directory -nobackup -force


### PR DESCRIPTION
There are a few minor improvements in this PR:
- I defined some fenced blocks language as `bash`. This is helpful because some IDEs (PyCharm, IntelliJ) allow for running these commands directly in the README file, if the language is defined.
- I added some files and paths to `.gitignore`. Those are the files copied around from the AEV distribution zip, the distribution zip file itself, and the Alfresco license.
- I modified both Alfresco and Share `Dockerfile`s to support older versions of docker-compose. Specifically, this was not an issue on `v2.24.6-desktop.1` (in my Mac M1 laptop), but it was on an Amazon Linux 2023 test instance.

I hope this is helpful!