### PR TITLE
Custom Transformer and oc override properties file mount fix.

### DIFF
--- a/alfresco/resources/customTransformer.json
+++ b/alfresco/resources/customTransformer.json
@@ -1,0 +1,20 @@
+{
+    "transformers": [
+        {
+            "transformerName": "imageToPdfViaTiff",
+            "transformerPipeline": [
+                {
+                    "transformerName": "imagemagick",
+                    "targetMediaType": "image/tiff"
+                },
+                {
+                    "transformerName": "imageToPdf"
+                }
+            ],
+            "supportedSourceAndTargetList": [],
+            "transformOptions": [
+                "imageToPdfOptions"
+            ]
+        }
+    ]
+}

--- a/compose.yaml
+++ b/compose.yaml
@@ -41,7 +41,7 @@ services:
     volumes:
       - ./alfresco/resources/openannotate-override-placeholders.properties:/usr/local/tomcat/shared/classes/openannotate-override-placeholders.properties
       - ./alfresco/resources/opencontent-override-placeholders.properties:/usr/local/tomcat/shared/classes/alfresco/module/com.tsgrp.opencontent/opencontent-override-placeholders.properties
-      - ./alfresco/resources/customTranformer.json:/usr/local/tomcat/shared/classes/alfresco/extension/transform/pipelines/customTranformer.json
+      - ./alfresco/resources/customTransformer.json:/usr/local/tomcat/shared/classes/alfresco/extension/transform/pipelines/customTransformer.json
       - ./alfresco/resources/default.policy:/usr/lib/jvm/jre/lib/security/default.policy
       - ./alfresco/resources/server.xml:/usr/local/tomcat/conf/server.xml
       - ./alfresco/license/TextLicense.l4j:/usr/local/tomcat/shared/classes/alfresco/module/com.tsgrp.opencontent/license/TextLicense.l4j

--- a/compose.yaml
+++ b/compose.yaml
@@ -40,6 +40,8 @@ services:
         "
     volumes:
       - ./alfresco/resources/openannotate-override-placeholders.properties:/usr/local/tomcat/shared/classes/openannotate-override-placeholders.properties
+      - ./alfresco/resources/opencontent-override-placeholders.properties:/usr/local/tomcat/shared/classes/alfresco/module/com.tsgrp.opencontent/opencontent-override-placeholders.properties
+      - ./alfresco/resources/customTranformer.json:/usr/local/tomcat/shared/classes/alfresco/extension/transform/pipelines/customTranformer.json
       - ./alfresco/resources/default.policy:/usr/lib/jvm/jre/lib/security/default.policy
       - ./alfresco/resources/server.xml:/usr/local/tomcat/conf/server.xml
       - ./alfresco/license/TextLicense.l4j:/usr/local/tomcat/shared/classes/alfresco/module/com.tsgrp.opencontent/license/TextLicense.l4j
@@ -84,9 +86,7 @@ services:
       SOLR_SOLR_PORT: "8983"
       SOLR_CREATE_ALFRESCO_DEFAULTS: "alfresco,archive"
       ALFRESCO_SECURE_COMMS: "secret"
-      SOLR_OPTS: "
-        -Dalfresco.secureComms.secret=2yhklsj27lx
-      "
+      SOLR_OPTS: "-Dalfresco.secureComms.secret=2yhklsj27lx"
 
   activemq:
     image: alfresco/alfresco-activemq:${ACTIVEMQ_TAG}


### PR DESCRIPTION
There was a recent support issue where the customer was facing issue trying to download annotated pdf for image files. (https://hyland.atlassian.net/browse/MNT-24526). 
The background for this issue were:
1. The correct property was not set in oc override porperties file so OC was not doing a PDF rendition for image files.
2. Even with correct properties set the transformation was failing since the custom transformer was not included in the installer. 